### PR TITLE
fix: support sql type BIGINT

### DIFF
--- a/src/main/java/com/manticore/jdbc/parquetwriter/JDBCParquetWriter.java
+++ b/src/main/java/com/manticore/jdbc/parquetwriter/JDBCParquetWriter.java
@@ -341,6 +341,11 @@ public class JDBCParquetWriter {
                             .named(columnName));
                     break;
                 case java.sql.Types.BIGINT:
+                    builder.addField((nullable == ResultSetMetaData.columnNoNulls
+                            ? Types.required(PrimitiveType.PrimitiveTypeName.INT64)
+                            : Types.optional(PrimitiveType.PrimitiveTypeName.INT64))
+                            .named(columnName));
+                    break;
                 case java.sql.Types.INTEGER:
                 case java.sql.Types.SMALLINT:
                 case java.sql.Types.TINYINT:


### PR DESCRIPTION
it raise exception when handle bigint:
 ```java
java.lang.UnsupportedOperationException: org.apache.parquet.column.values.dictionary.DictionaryValuesWriter$PlainIntegerDictionaryValuesWriter
        at org.apache.parquet.column.values.ValuesWriter.writeLong(ValuesWriter.java:119)
        at org.apache.parquet.column.values.fallback.FallbackValuesWriter.writeLong(FallbackValuesWriter.java:192)
```
we need also treat the schema of  bigint as int64.
fixes #6
 